### PR TITLE
Add MFI gamepad support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Controls from './components/Controls';
 import Joystick from './components/Joystick';
 import JoystickPosition from './components/JoystickPosition';
+import GamepadStatus from './components/GamepadStatus';
 import { mqttService } from './services/MqttConnect';
 import { watchdogService } from './services/watchdog';
 
@@ -51,6 +52,7 @@ const App = () => {
       <Joystick />
     </div>
     <div className="fixed bottom-0 left-0 right-0 bg-white p-2 shadow-lg">
+      <GamepadStatus />
     </div>
   </div>
   );

--- a/src/components/Controls.js
+++ b/src/components/Controls.js
@@ -1,9 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { mqttService } from '../services/MqttConnect';
+import useGamepad from '../hooks/useGamepad';
 
 const Controls = () => {
   const [isRunning, setIsRunning] = useState(false);
   const [sliderValue, setSliderValue] = useState(50);
+const gamepadState = useGamepad();
+
+useEffect(() => {
+  if (gamepadState.sliderValue !== undefined) {
+    setSliderValue(gamepadState.sliderValue);
+  }
+}, [gamepadState.sliderValue]);
 
   const handleStartStop = () => {
     setIsRunning(!isRunning);

--- a/src/components/GamepadStatus.js
+++ b/src/components/GamepadStatus.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import useGamepad from '../hooks/useGamepad';
+
+const GamepadStatus = () => {
+  const gamepadState = useGamepad();
+
+  return (
+    <div className="text-sm text-gray-600 mt-2">
+      {gamepadState.isConnected ? (
+        <span className="text-green-600">
+          ゲームパッド接続中
+        </span>
+      ) : (
+        <span className="text-gray-400">
+          ゲームパッド未接続
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default GamepadStatus;

--- a/src/components/Joystick.js
+++ b/src/components/Joystick.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { mqttService } from '../services/MqttConnect';
+import useGamepad from '../hooks/useGamepad';
 
 const Joystick = () => {
   const joystickRef = useRef(null);
@@ -8,6 +9,7 @@ const Joystick = () => {
   const position = useRef({ x: 0, y: 0 });
   const animationFrameRef = useRef(null);
   const lastPublishRef = useRef(0);
+  const gamepadState = useGamepad();
 
   useEffect(() => {
     let rect = null;

--- a/src/hooks/useGamepad.js
+++ b/src/hooks/useGamepad.js
@@ -8,7 +8,10 @@ const useGamepad = () => {
     buttons: {},
     isConnected: false,
     lastButtonA: false,
-    lastButtonB: false
+    lastButtonB: false,
+    lastButtonPlus: false,
+    lastButtonMinus: false,
+    sliderValue: 50 // スライダーの初期値を50に設定
   });
 
   useEffect(() => {
@@ -23,6 +26,8 @@ const useGamepad = () => {
         const now = Date.now();
         const buttonA = gamepad.buttons[0]?.pressed || false;
         const buttonB = gamepad.buttons[1]?.pressed || false;
+        const buttonPlus = gamepad.buttons[4]?.pressed || false;
+        const buttonMinus = gamepad.buttons[5]?.pressed || false;
 
         const newState = {
           leftStick: {
@@ -36,7 +41,10 @@ const useGamepad = () => {
           buttons: gamepad.buttons.map(btn => btn.pressed),
           isConnected: true,
           lastButtonA: buttonA,
-          lastButtonB: buttonB
+          lastButtonB: buttonB,
+          lastButtonPlus: buttonPlus,
+          lastButtonMinus: buttonMinus,
+          sliderValue: gamepadState.sliderValue
         };
 
         setGamepadState(prevState => {
@@ -46,6 +54,14 @@ const useGamepad = () => {
           }
           if (buttonB && !prevState.lastButtonB) {
             mqttService.publish('control/startStop', false);
+          }
+          if (buttonPlus && !prevState.lastButtonPlus) {
+            const newSliderValue = Math.min(100, prevState.sliderValue + 10);
+            mqttService.publish('control/slider', newSliderValue);
+          }
+          if (buttonMinus && !prevState.lastButtonMinus) {
+            const newSliderValue = Math.max(0, prevState.sliderValue - 10);
+            mqttService.publish('control/slider', newSliderValue);
           }
           return newState;
         });

--- a/src/hooks/useGamepad.js
+++ b/src/hooks/useGamepad.js
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import { mqttService } from '../services/MqttConnect';
+
+const useGamepad = () => {
+  const [gamepadState, setGamepadState] = useState({
+    leftStick: { x: 0, y: 0 },
+    rightStick: { x: 0, y: 0 },
+    buttons: {},
+    isConnected: false
+  });
+
+  useEffect(() => {
+    let animationFrameId;
+    let lastPublishTime = 0;
+
+    const handleGamepadInput = () => {
+      const gamepads = navigator.getGamepads();
+      const gamepad = gamepads[0]; // MFIコントローラーは通常index 0に接続される
+
+      if (gamepad) {
+        const now = Date.now();
+        const newState = {
+          leftStick: {
+            x: Math.round(gamepad.axes[0] * 100),
+            y: Math.round(-gamepad.axes[1] * 100) // Y軸は反転
+          },
+          rightStick: {
+            x: Math.round(gamepad.axes[2] * 100),
+            y: Math.round(-gamepad.axes[3] * 100)
+          },
+          buttons: gamepad.buttons.map(btn => btn.pressed),
+          isConnected: true
+        };
+
+        setGamepadState(newState);
+
+        // 100ms毎にMQTTメッセージを送信
+        if (now - lastPublishTime > 100) {
+          mqttService.publish('control/joystick/x', newState.leftStick.x);
+          mqttService.publish('control/joystick/y', newState.leftStick.y);
+          lastPublishTime = now;
+        }
+      }
+
+      animationFrameId = requestAnimationFrame(handleGamepadInput);
+    };
+
+    const handleGamepadConnected = (e) => {
+      console.log('Gamepad connected:', e.gamepad);
+      handleGamepadInput();
+    };
+
+    const handleGamepadDisconnected = (e) => {
+      console.log('Gamepad disconnected:', e.gamepad);
+      setGamepadState(prev => ({ ...prev, isConnected: false }));
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+
+    window.addEventListener('gamepadconnected', handleGamepadConnected);
+    window.addEventListener('gamepaddisconnected', handleGamepadDisconnected);
+
+    return () => {
+      window.removeEventListener('gamepadconnected', handleGamepadConnected);
+      window.removeEventListener('gamepaddisconnected', handleGamepadDisconnected);
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, []);
+
+  return gamepadState;
+};
+
+export default useGamepad;


### PR DESCRIPTION
このPRでは、iPhoneに接続されたMFIゲームパッド（コントローラー）のサポートを追加します。

主な変更点：
- ゲームパッドの入力を検出するカスタムフック（useGamepad）の追加
- ゲームパッドの左スティックの入力をMQTTメッセージとして送信
- ゲームパッドの接続状態を表示するコンポーネントの追加

ゲームパッドが接続されている場合、左スティックの入力が自動的にMQTTメッセージとして送信されます。タッチ操作とゲームパッド操作は併用可能です。