### PR TITLE
Sync gamepad button states with start/stop UI

### DIFF
--- a/src/components/Controls.js
+++ b/src/components/Controls.js
@@ -3,9 +3,17 @@ import { mqttService } from '../services/MqttConnect';
 import useGamepad from '../hooks/useGamepad';
 
 const Controls = () => {
+  const gamepadState = useGamepad();
   const [isRunning, setIsRunning] = useState(false);
   const [sliderValue, setSliderValue] = useState(50);
-const gamepadState = useGamepad();
+
+  useEffect(() => {
+    if (gamepadState.lastButtonA && !gamepadState.lastButtonB) {
+      setIsRunning(true);
+    } else if (!gamepadState.lastButtonA && gamepadState.lastButtonB) {
+      setIsRunning(false);
+    }
+  }, [gamepadState.lastButtonA, gamepadState.lastButtonB]);
 
 useEffect(() => {
   if (gamepadState.sliderValue !== undefined) {


### PR DESCRIPTION
ゲームパッドのA/Bボタン押下時にStart/Stopボタンの状態が同期されるように修正しました。

- useGamepadフックからボタン状態を取得
- useEffectで状態変化を監視
- ボタン押下に応じてisRunning状態を更新